### PR TITLE
Fix status bar overlap on iOS 7

### DIFF
--- a/iOS/zurich/Classes/MainViewController.m
+++ b/iOS/zurich/Classes/MainViewController.m
@@ -53,11 +53,18 @@
     // Set the main view to utilize the entire application frame space of the device.
     // Change this to suit your view's UI footprint needs in your application.
 
-    UIView* rootView = [[[[UIApplication sharedApplication] keyWindow] rootViewController] view];
-    CGRect webViewFrame = [[[rootView subviews] objectAtIndex:0] frame];  // first subview is the UIWebView
+    if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7) {
+        CGRect viewBounds = [self.webView bounds];
+        viewBounds.origin.y = 20;
+        viewBounds.size.height = viewBounds.size.height - 20;
+        self.webView.frame = viewBounds;
+    } else {
+        UIView* rootView = [[[[UIApplication sharedApplication] keyWindow] rootViewController] view];
+        CGRect webViewFrame = [[[rootView subviews] objectAtIndex:0] frame];  // first subview is the UIWebView
 
-    if (CGRectEqualToRect(webViewFrame, CGRectZero)) { // UIWebView is sized according to its parent, here it hasn't been sized yet
-        self.view.frame = [[UIScreen mainScreen] applicationFrame]; // size UIWebView's parent according to application frame, which will in turn resize the UIWebView
+        if (CGRectEqualToRect(webViewFrame, CGRectZero)) { // UIWebView is sized according to its parent, here it hasn't been sized yet
+            self.view.frame = [[UIScreen mainScreen] applicationFrame]; // size UIWebView's parent according to application frame, which will in turn resize the UIWebView
+        }
     }
 
     [super viewWillAppear:animated];


### PR DESCRIPTION
This uses an adapted version of [this code found on SO](http://stackoverflow.com/a/19249775/372120). It has been modified so that the existing code (which performs a similar status bar fix for iOS 6) continues to operate for those using an older version of iOS.

I originally attempted to fix this in the javascript, but the way junior.css uses position: fixed to layout the page seemed to resist my attempts to change it.

Closes #2 

@struan Does this look like a reasonable solution to this issue? Or would it be better for me to figure out how to do this in js/css with junior?
### iOS 6

![screen shot 2013-11-06 at 17 46 34](https://f.cloud.github.com/assets/22996/1484844/8d3c972a-470c-11e3-9237-354bdbd8868b.png)
### iOS7

![screen shot 2013-11-06 at 17 46 48](https://f.cloud.github.com/assets/22996/1484847/92165d1c-470c-11e3-91b9-9780750e7bb8.png)
